### PR TITLE
Transition to remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: librarian
 Title: Install, Update, Load Packages from CRAN, 'GitHub', and 'Bioconductor' in One Step
-Version: 1.5.5
+Version: 1.5.6
 Date: 2019-02-18
 Authors@R: person("Desi", "Quintans", email = "science@desiquintans.com",
                   role = c("aut", "cre"))
@@ -14,9 +14,9 @@ License: GPL-3
 Encoding: UTF-8
 Imports:
     backports (>= 1.1.2),
-    devtools (>= 1.13.0),
+    remotes (>= 2.0.0),
     tools (>= 3.4.0),
     utils (>= 3.4.0)
 LazyData: true
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1
 Suggests: testthat

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # librarian 1.5.5 (2019-02-18)
 
 - FIX - `nse_dots()` used to insert spaces in names that included `-` because it was formatting them nicely as if they were expressions with the minus operator. The function now removes any spaces that were created in the process of converting from a symbol to a string. Closes [#13](https://github.com/DesiQuintans/librarian/issues/13).
-
+- MOD - `remotes` replaces `devtools`. Closes [#11](https://github.com/DesiQuintans/librarian/issues/11).
 
 
 # librarian 1.5.4 (2019-02-15)

--- a/R/package_tools.R
+++ b/R/package_tools.R
@@ -129,7 +129,7 @@ shelf <- function(..., lib = lib_paths(), update_all = FALSE, quiet = FALSE, ask
     
     if (length(github_missing) > 0) {
         suppress_lib_message(
-            devtools::install_github(github_missing, quiet = quiet)
+            remotes::install_github(github_missing, quiet = quiet)
         )
     }
     

--- a/librarian.Rproj
+++ b/librarian.Rproj
@@ -12,6 +12,8 @@ Encoding: UTF-8
 RnwWeave: Sweave
 LaTeX: pdfLaTeX
 
+AutoAppendNewline: Yes
+
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
Switching from `devtools` to `remotes` is a convenience that saves users from installing all of `devtools`' s dependencies. Closes #11 