### PR TITLE
fixed what looked like an infinite loop in the shelf function

### DIFF
--- a/R/exported_functions.R
+++ b/R/exported_functions.R
@@ -58,7 +58,7 @@
 #' }
 #' 
 #' @md
-shelf <- function(..., lib = lib_paths(), update_all = FALSE, quiet = FALSE, ask = TRUE,
+shelf <- function(..., lib = NULL, update_all = FALSE, quiet = FALSE, ask = TRUE,
                   cran_repo = getOption("repos"), bioc_repo = character()) {
 
     # Sanitise user input


### PR DESCRIPTION
I too was getting the 
```
Error in lib_paths(lib, make_path = TRUE, ask = ask) : 
  The paths

  '-1'

  are not writeable`
```
error.  Looking at `shelf()`, it appears that the `lib` argument has the default value of calling `lib_paths()`, so that you get
``` lib = libpaths()
lib_paths(lib = lib_paths())
```
As far as I can tell, setting the default value of `lib` to `NULL` has the same effect, but avoids the error.